### PR TITLE
remove the methods that can execute command with lots of NoBUG

### DIFF
--- a/NeoBurgerGovernanceToken.cs
+++ b/NeoBurgerGovernanceToken.cs
@@ -41,16 +41,6 @@ namespace NeoBurger
             ExecutionEngine.Assert(Runtime.CheckWitness(TEE()) && NotPaused());
             new StorageMap(Storage.CurrentContext, PREFIX_EXECUTION).Put(digest, Runtime.Time + DEFAULT_WAITTIME);
         }
-        public static void SubmitExecution(UInt160 caller, UInt256 digest)
-        {
-            ExecutionEngine.Assert(Runtime.CheckWitness(caller) && BalanceOf(caller) * 2 > TotalSupply());
-            new StorageMap(Storage.CurrentContext, PREFIX_EXECUTION).Put(digest, Runtime.Time + DEFAULT_WAITTIME / 2);
-        }
-        public static void BanExecution(UInt160 caller, UInt256 digest)
-        {
-            ExecutionEngine.Assert(Runtime.CheckWitness(caller) && BalanceOf(caller) * 2 > TotalSupply());
-            new StorageMap(Storage.CurrentContext, PREFIX_EXECUTED).Put(digest, -1);
-        }
         public static object Execute(UInt160 scripthash, string method, object[] args, BigInteger nonce)
         {
             ExecutionEngine.Assert(NotPaused());
@@ -96,11 +86,6 @@ namespace NeoBurger
         {
             ExecutionEngine.Assert(Runtime.CheckWitness(Runtime.ExecutingScriptHash));
             Storage.Put(Storage.CurrentContext, new byte[] { PREFIX_MINTROOT }, root);
-        }
-        public static void PauseDAO(UInt160 caller)
-        {
-            ExecutionEngine.Assert(Runtime.CheckWitness(caller) && BalanceOf(caller) > TotalSupply() / 4);
-            Storage.Put(Storage.CurrentContext, new byte[] { PREFIX_PAUSEUNTIL }, Runtime.Time + DEFAULT_WAITTIME);
         }
         public static void Update(ByteString nefFile, string manifest)
         {


### PR DESCRIPTION
Because we decided to using the DAO on EVM chain. We do not need these two methods anymore.