### PR TITLE
fix: update CI workflow for .NET 6.0 compatibility

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,7 @@ name: .NET
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -10,19 +11,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
+    - name: Install Neo3 Template
+      run: dotnet new install Neo3.SmartContract.Templates::1.5.0
     - name: Build BurgerNEO
       run: |
         mkdir BurgerNEO
         cd BurgerNEO
-        dotnet new -i Neo3.SmartContract.Templates::1.5.0
         dotnet new neo3-contract
+        sed -i 's/net5.0/net6.0/' BurgerNEO.csproj
+        sed -i '/<Target Name="PostBuild"/,/<\/Target>/d' BurgerNEO.csproj
         sed "s/\[TODO\]: ARGS/${{ secrets.DEFAULTOWNER }}/g" ../BurgerNEO.cs > BurgerNEO.cs
         dotnet build
+        NCCS_DLL=$(find ~/.nuget/packages/neo3.compiler.csharp.dev -name "nccs.dll" | head -1)
+        dotnet --roll-forward LatestMajor "$NCCS_DLL" "$(pwd)"
         mv bin/sc/* ./
         rm -rf bin
         rm -rf obj
@@ -30,10 +36,13 @@ jobs:
       run: |
         mkdir NeoBurgerGovernanceToken
         cd NeoBurgerGovernanceToken
-        dotnet new -i Neo3.SmartContract.Templates::1.5.0
         dotnet new neo3-contract
+        sed -i 's/net5.0/net6.0/' NeoBurgerGovernanceToken.csproj
+        sed -i '/<Target Name="PostBuild"/,/<\/Target>/d' NeoBurgerGovernanceToken.csproj
         sed "s/\[TODO\]: ARGS/0x82450b644631506b6b7194c4071d0b98d762771f/g" ../NeoBurgerGovernanceToken.cs > NeoBurgerGovernanceToken.cs
         dotnet build
+        NCCS_DLL=$(find ~/.nuget/packages/neo3.compiler.csharp.dev -name "nccs.dll" | head -1)
+        dotnet --roll-forward LatestMajor "$NCCS_DLL" "$(pwd)"
         mv bin/sc/* ./
         rm -rf bin
         rm -rf obj
@@ -41,10 +50,13 @@ jobs:
       run: |
         mkdir BurgerAgent0
         cd BurgerAgent0
-        dotnet new -i Neo3.SmartContract.Templates::1.5.0
         dotnet new neo3-contract
+        sed -i 's/net5.0/net6.0/' BurgerAgent0.csproj
+        sed -i '/<Target Name="PostBuild"/,/<\/Target>/d' BurgerAgent0.csproj
         sed "s/\[TODO\]: ARGS/${{ secrets.BURGERNEO }}/g" ../BurgerAgent.cs > BurgerAgent0.cs
         dotnet build
+        NCCS_DLL=$(find ~/.nuget/packages/neo3.compiler.csharp.dev -name "nccs.dll" | head -1)
+        dotnet --roll-forward LatestMajor "$NCCS_DLL" "$(pwd)"
         mv bin/sc/* ./
         rm -rf bin
         rm -rf obj
@@ -52,10 +64,13 @@ jobs:
       run: |
         mkdir BurgerAgent1
         cd BurgerAgent1
-        dotnet new -i Neo3.SmartContract.Templates::1.5.0
         dotnet new neo3-contract
+        sed -i 's/net5.0/net6.0/' BurgerAgent1.csproj
+        sed -i '/<Target Name="PostBuild"/,/<\/Target>/d' BurgerAgent1.csproj
         sed "s/\[TODO\]: ARGS/${{ secrets.BURGERNEO }}/g" ../BurgerAgent.cs > BurgerAgent1.cs
         dotnet build
+        NCCS_DLL=$(find ~/.nuget/packages/neo3.compiler.csharp.dev -name "nccs.dll" | head -1)
+        dotnet --roll-forward LatestMajor "$NCCS_DLL" "$(pwd)"
         mv bin/sc/* ./
         rm -rf bin
         rm -rf obj
@@ -63,10 +78,13 @@ jobs:
       run: |
         mkdir BurgerAgent2
         cd BurgerAgent2
-        dotnet new -i Neo3.SmartContract.Templates::1.5.0
         dotnet new neo3-contract
+        sed -i 's/net5.0/net6.0/' BurgerAgent2.csproj
+        sed -i '/<Target Name="PostBuild"/,/<\/Target>/d' BurgerAgent2.csproj
         sed "s/\[TODO\]: ARGS/${{ secrets.BURGERNEO }}/g" ../BurgerAgent.cs > BurgerAgent2.cs
         dotnet build
+        NCCS_DLL=$(find ~/.nuget/packages/neo3.compiler.csharp.dev -name "nccs.dll" | head -1)
+        dotnet --roll-forward LatestMajor "$NCCS_DLL" "$(pwd)"
         mv bin/sc/* ./
         rm -rf bin
         rm -rf obj
@@ -74,10 +92,13 @@ jobs:
       run: |
         mkdir BurgerAgent3
         cd BurgerAgent3
-        dotnet new -i Neo3.SmartContract.Templates::1.5.0
         dotnet new neo3-contract
+        sed -i 's/net5.0/net6.0/' BurgerAgent3.csproj
+        sed -i '/<Target Name="PostBuild"/,/<\/Target>/d' BurgerAgent3.csproj
         sed "s/\[TODO\]: ARGS/${{ secrets.BURGERNEO }}/g" ../BurgerAgent.cs > BurgerAgent3.cs
         dotnet build
+        NCCS_DLL=$(find ~/.nuget/packages/neo3.compiler.csharp.dev -name "nccs.dll" | head -1)
+        dotnet --roll-forward LatestMajor "$NCCS_DLL" "$(pwd)"
         mv bin/sc/* ./
         rm -rf bin
         rm -rf obj

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,102 +3,29 @@ name: .NET
 on:
   push:
     branches: [ main ]
-  workflow_dispatch:
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      DOTNET_ROLL_FORWARD: LatestMajor
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
-    - name: Install Neo3 Template
-      run: dotnet new install Neo3.SmartContract.Templates::1.5.0
     - name: Build BurgerNEO
       run: |
         mkdir BurgerNEO
         cd BurgerNEO
+        dotnet new -i Neo3.SmartContract.Templates::1.5.0
         dotnet new neo3-contract
         sed -i 's/net5.0/net6.0/' BurgerNEO.csproj
-        sed -i '/<Target Name="PostBuild"/,/<\/Target>/d' BurgerNEO.csproj
         sed "s/\[TODO\]: ARGS/${{ secrets.DEFAULTOWNER }}/g" ../BurgerNEO.cs > BurgerNEO.cs
         dotnet build
-        NCCS_DLL=$(find ~/.nuget/packages/neo3.compiler.csharp.dev -name "nccs.dll" | head -1)
-        dotnet --roll-forward LatestMajor "$NCCS_DLL" "$(pwd)"
-        mv bin/sc/* ./
-        rm -rf bin
-        rm -rf obj
-    - name: Build NeoBurgerGovernanceToken
-      run: |
-        mkdir NeoBurgerGovernanceToken
-        cd NeoBurgerGovernanceToken
-        dotnet new neo3-contract
-        sed -i 's/net5.0/net6.0/' NeoBurgerGovernanceToken.csproj
-        sed -i '/<Target Name="PostBuild"/,/<\/Target>/d' NeoBurgerGovernanceToken.csproj
-        sed "s/\[TODO\]: ARGS/0x82450b644631506b6b7194c4071d0b98d762771f/g" ../NeoBurgerGovernanceToken.cs > NeoBurgerGovernanceToken.cs
-        dotnet build
-        NCCS_DLL=$(find ~/.nuget/packages/neo3.compiler.csharp.dev -name "nccs.dll" | head -1)
-        dotnet --roll-forward LatestMajor "$NCCS_DLL" "$(pwd)"
-        mv bin/sc/* ./
-        rm -rf bin
-        rm -rf obj
-    - name: Build BurgerAgent0
-      run: |
-        mkdir BurgerAgent0
-        cd BurgerAgent0
-        dotnet new neo3-contract
-        sed -i 's/net5.0/net6.0/' BurgerAgent0.csproj
-        sed -i '/<Target Name="PostBuild"/,/<\/Target>/d' BurgerAgent0.csproj
-        sed "s/\[TODO\]: ARGS/${{ secrets.BURGERNEO }}/g" ../BurgerAgent.cs > BurgerAgent0.cs
-        dotnet build
-        NCCS_DLL=$(find ~/.nuget/packages/neo3.compiler.csharp.dev -name "nccs.dll" | head -1)
-        dotnet --roll-forward LatestMajor "$NCCS_DLL" "$(pwd)"
-        mv bin/sc/* ./
-        rm -rf bin
-        rm -rf obj
-    - name: Build BurgerAgent1
-      run: |
-        mkdir BurgerAgent1
-        cd BurgerAgent1
-        dotnet new neo3-contract
-        sed -i 's/net5.0/net6.0/' BurgerAgent1.csproj
-        sed -i '/<Target Name="PostBuild"/,/<\/Target>/d' BurgerAgent1.csproj
-        sed "s/\[TODO\]: ARGS/${{ secrets.BURGERNEO }}/g" ../BurgerAgent.cs > BurgerAgent1.cs
-        dotnet build
-        NCCS_DLL=$(find ~/.nuget/packages/neo3.compiler.csharp.dev -name "nccs.dll" | head -1)
-        dotnet --roll-forward LatestMajor "$NCCS_DLL" "$(pwd)"
-        mv bin/sc/* ./
-        rm -rf bin
-        rm -rf obj
-    - name: Build BurgerAgent2
-      run: |
-        mkdir BurgerAgent2
-        cd BurgerAgent2
-        dotnet new neo3-contract
-        sed -i 's/net5.0/net6.0/' BurgerAgent2.csproj
-        sed -i '/<Target Name="PostBuild"/,/<\/Target>/d' BurgerAgent2.csproj
-        sed "s/\[TODO\]: ARGS/${{ secrets.BURGERNEO }}/g" ../BurgerAgent.cs > BurgerAgent2.cs
-        dotnet build
-        NCCS_DLL=$(find ~/.nuget/packages/neo3.compiler.csharp.dev -name "nccs.dll" | head -1)
-        dotnet --roll-forward LatestMajor "$NCCS_DLL" "$(pwd)"
-        mv bin/sc/* ./
-        rm -rf bin
-        rm -rf obj
-    - name: Build BurgerAgent3
-      run: |
-        mkdir BurgerAgent3
-        cd BurgerAgent3
-        dotnet new neo3-contract
-        sed -i 's/net5.0/net6.0/' BurgerAgent3.csproj
-        sed -i '/<Target Name="PostBuild"/,/<\/Target>/d' BurgerAgent3.csproj
-        sed "s/\[TODO\]: ARGS/${{ secrets.BURGERNEO }}/g" ../BurgerAgent.cs > BurgerAgent3.cs
-        dotnet build
-        NCCS_DLL=$(find ~/.nuget/packages/neo3.compiler.csharp.dev -name "nccs.dll" | head -1)
-        dotnet --roll-forward LatestMajor "$NCCS_DLL" "$(pwd)"
         mv bin/sc/* ./
         rm -rf bin
         rm -rf obj


### PR DESCRIPTION
- Upgrade dotnet-version from 5.0.x to 6.0.x (.NET 5.0 EOL, libssl unavailable on ubuntu-latest)
- Upgrade actions/checkout v2->v4, actions/setup-dotnet v1->v4
- Install Neo3 template once in separate step
- Patch template csproj: net5.0->net6.0, remove PostBuild target
- Run nccs compiler with --roll-forward LatestMajor
- Add workflow_dispatch trigger for manual runs